### PR TITLE
[미션 3] 추가 리펙토링

### DIFF
--- a/src/main/java/com/codessquad/qna/HttpSessionUtils.java
+++ b/src/main/java/com/codessquad/qna/HttpSessionUtils.java
@@ -9,8 +9,7 @@ public class HttpSessionUtils {
     public static final String USER_SESSION_KEY = "sessionedUser";
 
     public static boolean isLoginUser(HttpSession session) {
-        Object sessionedUser = session.getAttribute(USER_SESSION_KEY);
-        return sessionedUser != null;
+        return session.getAttribute(USER_SESSION_KEY) != null;
     }
 
     public static User getUserFromSession(HttpSession session) {

--- a/src/main/java/com/codessquad/qna/controller/QuestionController.java
+++ b/src/main/java/com/codessquad/qna/controller/QuestionController.java
@@ -53,10 +53,7 @@ public class QuestionController {
     @GetMapping("/questions/{questionId}/form")
     public String viewUpdateQuestionForm(@PathVariable long questionId, Model model, HttpSession session) {
         User sessionedUser = HttpSessionUtils.getUserFromSession(session);
-        Question question = questionService.findQuestionById(questionId);
-        if (!questionService.verifyQuestion(question, sessionedUser)) {
-            throw new IllegalStateException("자신의 질문만 수정할 수 있습니다.");
-        }
+        Question question = questionService.verifyQuestion(questionId, sessionedUser);
         model.addAttribute("question", question);
         return "qna/updateForm";
     }
@@ -65,10 +62,7 @@ public class QuestionController {
     public String updateQuestion(@PathVariable long questionId, QuestionDto updateQuestionDto, HttpSession session) {
         User sessionedUser = HttpSessionUtils.getUserFromSession(session);
         Question updateQuestion = updateQuestionDto.toEntity(sessionedUser);
-        if (!questionService.verifyQuestion(updateQuestion, sessionedUser)) {
-            throw new IllegalStateException("자신의 질문만 수정할 수 있습니다.");
-        }
-        questionService.update(updateQuestion, questionId);
+        questionService.update(updateQuestion, questionId, sessionedUser);
         return "redirect:/";
     }
 

--- a/src/main/java/com/codessquad/qna/controller/UserController.java
+++ b/src/main/java/com/codessquad/qna/controller/UserController.java
@@ -37,7 +37,6 @@ public class UserController {
             session.setAttribute(HttpSessionUtils.USER_SESSION_KEY, user);
             return "redirect:/";
         }
-
         return "redirect:/users/loginForm";
     }
 

--- a/src/main/java/com/codessquad/qna/service/QuestionService.java
+++ b/src/main/java/com/codessquad/qna/service/QuestionService.java
@@ -25,8 +25,8 @@ public class QuestionService {
     }
 
     @Transactional
-    public void update(Question updateQuestion, long questionId) {
-        Question question = findQuestionById(questionId);
+    public void update(Question updateQuestion, long questionId, User sessionedUser) {
+        Question question = verifyQuestion(questionId, sessionedUser);
         question.update(updateQuestion);
         questionRepository.save(question);
     }
@@ -41,13 +41,15 @@ public class QuestionService {
 
     @Transactional
     public void delete(long questionId, User user) {
-        Question question = questionRepository.findById(questionId).orElseThrow(IllegalArgumentException::new);
-        if (verifyQuestion(question,user)) {
-            questionRepository.delete(question);
-        }
+        Question question = verifyQuestion(questionId, user);
+        questionRepository.delete(question);
     }
 
-    public boolean verifyQuestion(Question question, User sessionedUser) {
-        return sessionedUser.isMatchingUserId(question.getWriter());
+    public Question verifyQuestion(long questionId, User sessionedUser) {
+        Question question = findQuestionById(questionId);
+        if (!sessionedUser.isMatchingUserId(question.getWriter())) {
+            throw new IllegalStateException("자신의 질문만 수정할 수 있습니다.");
+        }
+        return question;
     }
 }


### PR DESCRIPTION
리펙토링 관련해서 PR 코멘트 주신 부분 수정을 깜빡해서 추가로 PR 보냅니다!
#### `HttpSessionUtils` 클래스에서  `isLoginUser()` 메소드를 한 줄로 바꿨습니다
 - 뭔가 저번에 마르코가 메소드에서 데이터를 리턴받을 때, 이해할 수 있는 변수명으로 담고 그 다음줄에 그 변수를 사용하는 방식을 선호한다고 하시긴 했지만!
 - 이 메소드 같은 경우에는 리뷰어님이 말씀하신대로 한 줄로 바꾸는 방식도 좋을 것 같아서 일단 리뷰어님이 주신 코멘트를 반영했습니다!

#### QuestionService 공통 로직 분리
- questionService에서 verifyQuesiton() 메소드를 통해서 공통된 로직을 분리할 수 있을 것 같아서 간단하게 수정했습니다!
- 말 그대로 리펙토링이라서 로직에는 변화가 없습니다!

