### PR TITLE
[미션4]  PR 수정

### DIFF
--- a/src/main/java/com/codessquad/qna/HandlebarHelper.java
+++ b/src/main/java/com/codessquad/qna/HandlebarHelper.java
@@ -7,6 +7,7 @@ import java.time.format.DateTimeFormatter;
 
 @HandlebarsHelper
 public class HandlebarHelper {
+
     private static final String ISO8601 = "yyyy-MM-dd HH:mm";
 
     private HandlebarHelper() {

--- a/src/main/java/com/codessquad/qna/HandlebarHelper.java
+++ b/src/main/java/com/codessquad/qna/HandlebarHelper.java
@@ -13,7 +13,7 @@ public class HandlebarHelper {
     private HandlebarHelper() {
     }
 
-    public static CharSequence formatDateTime(LocalDateTime time) {
-        return time.format(DateTimeFormatter.ofPattern(ISO8601));
+    public static CharSequence formatDateTime(LocalDateTime createdAt) {
+        return createdAt.format(DateTimeFormatter.ofPattern(ISO8601));
     }
 }

--- a/src/main/java/com/codessquad/qna/HttpSessionUtils.java
+++ b/src/main/java/com/codessquad/qna/HttpSessionUtils.java
@@ -6,6 +6,7 @@ import com.codessquad.qna.exception.NotLoginException;
 import javax.servlet.http.HttpSession;
 
 public class HttpSessionUtils {
+
     public static final String USER_SESSION_KEY = "sessionedUser";
 
     public static boolean isLoginUser(HttpSession session) {
@@ -18,5 +19,4 @@ public class HttpSessionUtils {
         }
         return (User) session.getAttribute(USER_SESSION_KEY);
     }
-
 }

--- a/src/main/java/com/codessquad/qna/QnaApplication.java
+++ b/src/main/java/com/codessquad/qna/QnaApplication.java
@@ -9,5 +9,4 @@ public class QnaApplication {
     public static void main(String[] args) {
         SpringApplication.run(QnaApplication.class, args);
     }
-
 }

--- a/src/main/java/com/codessquad/qna/controller/AnswerController.java
+++ b/src/main/java/com/codessquad/qna/controller/AnswerController.java
@@ -16,8 +16,11 @@ import javax.servlet.http.HttpSession;
 public class AnswerController {
 
     private final AnswerService answerService;
+    private final QuestionService questionService;
 
-    public AnswerController(AnswerService answerService) {
+    public AnswerController(AnswerService answerService, QuestionService questionService) {
+
+        this.questionService = questionService;
         this.answerService = answerService;
     }
 
@@ -29,9 +32,15 @@ public class AnswerController {
     }
 
     @DeleteMapping("/{answerId}")
-    public String deleteAnswer(@PathVariable long answerId, HttpSession session) {
+    public String deleteAnswer(@PathVariable long questionId, @PathVariable long answerId, HttpSession session, Model model) {
         User sessionedUser = HttpSessionUtils.getUserFromSession(session);
-        long questionId = answerService.delete(answerId, sessionedUser);
+        Answer answer = answerService.findAnswerByAnswerId(answerId);
+        if (!answerService.delete(answer, sessionedUser)) {
+            model.addAttribute("error", "자신의 답변만 삭제할 수 있습니다.");
+            model.addAttribute("question", questionService.findQuestionById(questionId));
+            model.addAttribute("answers", answerService.findAnswersByQuestionId(questionId));
+            return "qna/show";
+        }
         return "redirect:/questions/" + questionId;
     }
 }

--- a/src/main/java/com/codessquad/qna/controller/AnswerController.java
+++ b/src/main/java/com/codessquad/qna/controller/AnswerController.java
@@ -22,7 +22,6 @@ public class AnswerController {
     private final QuestionService questionService;
 
     public AnswerController(AnswerService answerService, QuestionService questionService) {
-
         this.questionService = questionService;
         this.answerService = answerService;
     }

--- a/src/main/java/com/codessquad/qna/controller/AnswerController.java
+++ b/src/main/java/com/codessquad/qna/controller/AnswerController.java
@@ -1,9 +1,12 @@
 package com.codessquad.qna.controller;
 
 import com.codessquad.qna.HttpSessionUtils;
+import com.codessquad.qna.domain.Answer;
 import com.codessquad.qna.domain.User;
 import com.codessquad.qna.service.AnswerService;
+import com.codessquad.qna.service.QuestionService;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/com/codessquad/qna/controller/HomeController.java
+++ b/src/main/java/com/codessquad/qna/controller/HomeController.java
@@ -1,0 +1,12 @@
+package com.codessquad.qna.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class HomeController {
+    @GetMapping("/")
+    public String visit(){
+        return "redirect:/questions";
+    }
+}

--- a/src/main/java/com/codessquad/qna/controller/HomeController.java
+++ b/src/main/java/com/codessquad/qna/controller/HomeController.java
@@ -5,8 +5,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 public class HomeController {
+
     @GetMapping("/")
-    public String visit(){
+    public String visit() {
         return "redirect:/questions";
     }
 }

--- a/src/main/java/com/codessquad/qna/controller/QuestionController.java
+++ b/src/main/java/com/codessquad/qna/controller/QuestionController.java
@@ -35,7 +35,7 @@ public class QuestionController {
     public String createQuestion(QuestionDto questionDto, HttpSession session) {
         User sessionedUser = HttpSessionUtils.getUserFromSession(session);
         questionService.create(questionDto, sessionedUser);
-        return "redirect:/";
+        return "redirect:/questions";
     }
 
     @GetMapping

--- a/src/main/java/com/codessquad/qna/controller/QuestionController.java
+++ b/src/main/java/com/codessquad/qna/controller/QuestionController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.servlet.http.HttpSession;
 
 @Controller
+@RequestMapping("/questions")
 public class QuestionController {
 
     private final QuestionService questionService;
@@ -23,34 +24,34 @@ public class QuestionController {
         this.answerService = answerService;
     }
 
-    @GetMapping("/questions/form")
+    @GetMapping("/form")
     public String viewQuestionForm(HttpSession session) {
         if (!HttpSessionUtils.isLoginUser(session))
             return "redirect:/users/loginForm";
         return "qna/form";
     }
 
-    @PostMapping("/questions")
+    @PostMapping
     public String createQuestion(QuestionDto questionDto, HttpSession session) {
         User sessionedUser = HttpSessionUtils.getUserFromSession(session);
         questionService.create(questionDto, sessionedUser);
         return "redirect:/";
     }
 
-    @GetMapping("/")
+    @GetMapping
     public String list(Model model) {
         model.addAttribute("questions", questionService.findQuestions());
         return "index";
     }
 
-    @GetMapping("/questions/{questionId}")
+    @GetMapping("/{questionId}")
     public String viewQuestion(@PathVariable long questionId, Model model) {
         model.addAttribute("question", questionService.findQuestionById(questionId));
         model.addAttribute("answers", answerService.findAnswersByQuestionId(questionId));
         return "qna/show";
     }
 
-    @GetMapping("/questions/{questionId}/form")
+    @GetMapping("/{questionId}/form")
     public String viewUpdateQuestionForm(@PathVariable long questionId, Model model, HttpSession session) {
         User sessionedUser = HttpSessionUtils.getUserFromSession(session);
         Question question = questionService.verifyQuestion(questionId, sessionedUser);
@@ -58,7 +59,7 @@ public class QuestionController {
         return "qna/updateForm";
     }
 
-    @PutMapping("/questions/{questionId}")
+    @PutMapping("/{questionId}")
     public String updateQuestion(@PathVariable long questionId, QuestionDto updateQuestionDto, HttpSession session) {
         User sessionedUser = HttpSessionUtils.getUserFromSession(session);
         Question updateQuestion = updateQuestionDto.toEntity(sessionedUser);
@@ -66,8 +67,8 @@ public class QuestionController {
         return "redirect:/questions/" + questionId;
     }
 
-    @DeleteMapping("/questions/{questionId}")
-    public String delete(@PathVariable long questionId, HttpSession session) {
+    @DeleteMapping("/{questionId}")
+    public String delete(@PathVariable long questionId, HttpSession session, Model model) {
         User sessionedUser = HttpSessionUtils.getUserFromSession(session);
         questionService.delete(questionId, sessionedUser);
         return "redirect:/";

--- a/src/main/java/com/codessquad/qna/controller/QuestionController.java
+++ b/src/main/java/com/codessquad/qna/controller/QuestionController.java
@@ -63,7 +63,7 @@ public class QuestionController {
         User sessionedUser = HttpSessionUtils.getUserFromSession(session);
         Question updateQuestion = updateQuestionDto.toEntity(sessionedUser);
         questionService.update(updateQuestion, questionId, sessionedUser);
-        return "redirect:/";
+        return "redirect:/questions/" + questionId;
     }
 
     @DeleteMapping("/questions/{questionId}")

--- a/src/main/java/com/codessquad/qna/controller/UserController.java
+++ b/src/main/java/com/codessquad/qna/controller/UserController.java
@@ -2,6 +2,7 @@ package com.codessquad.qna.controller;
 
 import com.codessquad.qna.HttpSessionUtils;
 import com.codessquad.qna.domain.User;
+import com.codessquad.qna.exception.NotLoginException;
 import com.codessquad.qna.service.UserService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,9 +26,12 @@ public class UserController {
 
     @PostMapping
     public String signUp(User user) {
-        userService.create(user);
-        logger.info(user.toString());
-        return "redirect:/users";
+        if (!user.isEmpty() && userService.isNewUser(user)) {
+            userService.create(user);
+            logger.info(user.toString());
+            return "redirect:/users";
+        }
+        return "user/create_failed";
     }
 
     @PostMapping("/login")

--- a/src/main/java/com/codessquad/qna/controller/UserController.java
+++ b/src/main/java/com/codessquad/qna/controller/UserController.java
@@ -37,11 +37,11 @@ public class UserController {
     @PostMapping("/login")
     public String login(String userId, String password, HttpSession session) {
         User user = userService.findUserByUserId(userId);
-        if (user.isMatchingPassword(password)) {
-            session.setAttribute(HttpSessionUtils.USER_SESSION_KEY, user);
-            return "redirect:/";
+        if (!user.isMatchingPassword(password)) {
+            throw new NotLoginException("로그인하실 수 없습니다.");
         }
-        return "redirect:/users/loginForm";
+        session.setAttribute(HttpSessionUtils.USER_SESSION_KEY, user);
+        return "redirect:/";
     }
 
     @GetMapping("/logout")

--- a/src/main/java/com/codessquad/qna/controller/UserController.java
+++ b/src/main/java/com/codessquad/qna/controller/UserController.java
@@ -66,20 +66,23 @@ public class UserController {
     public String viewUpdateUserForm(@PathVariable Long id, Model model, HttpSession session) {
         User sessionedUser = HttpSessionUtils.getUserFromSession(session);
         if (!sessionedUser.isMatchingId(id)) {
-            throw new IllegalStateException("자신의 정보만 수정할 수 있습니다.");
+            model.addAttribute("users", userService.findUsers());
+            model.addAttribute("error", "자신의 정보만 수정할 수 있습니다.");
+            return "user/list";
         }
         model.addAttribute("user", sessionedUser);
         return "user/updateForm";
     }
 
-    @PutMapping("{id}/update")
-    public String updateUser(@PathVariable Long id, String oldPassword, User updateUser) {
+    @PutMapping("{id}")
+    public String updateUser(@PathVariable Long id, Model model, String oldPassword, User updateUser) {
         User targetUser = userService.findUserById(id);
         if (targetUser.isMatchingPassword(oldPassword)) {
             targetUser.update(updateUser);
             userService.create(targetUser);
             return "redirect:/users";
         }
-        return "redirect:/users/{id}/form";
+        model.addAttribute("user", targetUser);
+        return "user/update_failed";
     }
 }

--- a/src/main/java/com/codessquad/qna/domain/Answer.java
+++ b/src/main/java/com/codessquad/qna/domain/Answer.java
@@ -55,7 +55,7 @@ public class Answer {
         return contents;
     }
 
-    public LocalDateTime getTime() {
+    public LocalDateTime getCreatedAt() {
         return createdAt;
     }
 

--- a/src/main/java/com/codessquad/qna/domain/Answer.java
+++ b/src/main/java/com/codessquad/qna/domain/Answer.java
@@ -26,7 +26,7 @@ public class Answer {
     @Column(nullable = false)
     private String contents;
 
-    private LocalDateTime time = LocalDateTime.now();
+    private LocalDateTime createdAt = LocalDateTime.now();
 
     @Column
     private Boolean isActive = true;
@@ -57,7 +57,7 @@ public class Answer {
     }
 
     public LocalDateTime getTime() {
-        return time;
+        return createdAt;
     }
 
     public boolean isMatchingWriter(User user){
@@ -71,7 +71,7 @@ public class Answer {
                 ", writer=" + writer +
                 ", question=" + question +
                 ", contents='" + contents + '\'' +
-                ", time='" + time + '\'' +
+                ", createdAt='" + createdAt + '\'' +
                 '}';
     }
 }

--- a/src/main/java/com/codessquad/qna/domain/Answer.java
+++ b/src/main/java/com/codessquad/qna/domain/Answer.java
@@ -28,8 +28,7 @@ public class Answer {
 
     private LocalDateTime createdAt = LocalDateTime.now();
 
-    @Column
-    private Boolean isActive = true;
+    private boolean isActive = true;
 
     protected Answer() {
     }

--- a/src/main/java/com/codessquad/qna/domain/Answer.java
+++ b/src/main/java/com/codessquad/qna/domain/Answer.java
@@ -7,7 +7,7 @@ import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
-@SQLDelete(sql = "UPDATE ANSWER SET is_active = '0' WHERE id = ?")
+@SQLDelete(sql = "UPDATE ANSWER SET is_active = 0 WHERE id = ?")
 @Where(clause = "is_active=1")
 public class Answer {
 
@@ -32,7 +32,6 @@ public class Answer {
     private Boolean isActive = true;
 
     protected Answer() {
-
     }
 
     public Answer(User writer, Question question, String contents) {

--- a/src/main/java/com/codessquad/qna/domain/Answer.java
+++ b/src/main/java/com/codessquad/qna/domain/Answer.java
@@ -61,6 +61,10 @@ public class Answer {
         return time;
     }
 
+    public boolean isMatchingWriter(User user){
+        return writer.equals(user);
+    }
+
     @Override
     public String toString() {
         return "Answer{" +

--- a/src/main/java/com/codessquad/qna/domain/Question.java
+++ b/src/main/java/com/codessquad/qna/domain/Question.java
@@ -33,7 +33,7 @@ public class Question {
     @Column
     private Boolean isActive = true;
 
-    private LocalDateTime time = LocalDateTime.now();
+    private LocalDateTime createdAt = LocalDateTime.now();
 
     protected Question() {
     }
@@ -45,7 +45,7 @@ public class Question {
     }
 
     public LocalDateTime getTime() {
-        return this.time;
+        return this.createdAt;
     }
 
     public long getId() {
@@ -75,7 +75,7 @@ public class Question {
     public void update(Question question) {
         this.writer = question.getWriter();
         this.contents = question.getContents();
-        this.time = question.getTime();
+        this.createdAt = question.getTime();
         this.title = question.getTitle();
     }
 

--- a/src/main/java/com/codessquad/qna/domain/Question.java
+++ b/src/main/java/com/codessquad/qna/domain/Question.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@SQLDelete(sql = "UPDATE QUESTION SET is_active = '0' WHERE id = ?")
+@SQLDelete(sql = "UPDATE QUESTION SET is_active = 0 WHERE id = ?")
 @Where(clause = "is_active=1")
 public class Question {
 
@@ -36,7 +36,6 @@ public class Question {
     private LocalDateTime time = LocalDateTime.now();
 
     protected Question() {
-
     }
 
     public Question(User writer, String title, String contents) {

--- a/src/main/java/com/codessquad/qna/domain/Question.java
+++ b/src/main/java/com/codessquad/qna/domain/Question.java
@@ -43,7 +43,7 @@ public class Question {
         this.contents = contents;
     }
 
-    public LocalDateTime getTime() {
+    public LocalDateTime getCreatedAt() {
         return this.createdAt;
     }
 
@@ -74,7 +74,7 @@ public class Question {
     public void update(Question question) {
         this.writer = question.getWriter();
         this.contents = question.getContents();
-        this.createdAt = question.getTime();
+        this.createdAt = question.getCreatedAt();
         this.title = question.getTitle();
     }
 

--- a/src/main/java/com/codessquad/qna/domain/Question.java
+++ b/src/main/java/com/codessquad/qna/domain/Question.java
@@ -30,8 +30,7 @@ public class Question {
     @Column(nullable = false)
     private String contents;
 
-    @Column
-    private Boolean isActive = true;
+    private boolean isActive = true;
 
     private LocalDateTime createdAt = LocalDateTime.now();
 

--- a/src/main/java/com/codessquad/qna/domain/Question.java
+++ b/src/main/java/com/codessquad/qna/domain/Question.java
@@ -69,6 +69,10 @@ public class Question {
         return contents;
     }
 
+    public boolean isMatchingWriter(User user){
+        return writer.equals(user);
+    }
+
     public void update(Question question) {
         this.writer = question.getWriter();
         this.contents = question.getContents();

--- a/src/main/java/com/codessquad/qna/domain/User.java
+++ b/src/main/java/com/codessquad/qna/domain/User.java
@@ -59,6 +59,10 @@ public class User {
         return this.userId.equals(user.userId);
     }
 
+    public boolean isEmpty(){
+        return userId.equals("")||password.equals("")||name.equals("")||email.equals("");
+    }
+
     public void update(User updateUser) {
         this.password = updateUser.password;
         this.name = updateUser.name;

--- a/src/main/java/com/codessquad/qna/domain/User.java
+++ b/src/main/java/com/codessquad/qna/domain/User.java
@@ -17,7 +17,6 @@ public class User {
     private String email;
 
     protected User() {
-
     }
 
     public User(String userId, String password, String name, String email) {
@@ -59,8 +58,8 @@ public class User {
         return this.userId.equals(user.userId);
     }
 
-    public boolean isEmpty(){
-        return userId.equals("")||password.equals("")||name.equals("")||email.equals("");
+    public boolean isEmpty() {
+        return userId.equals("") || password.equals("") || name.equals("") || email.equals("");
     }
 
     public void update(User updateUser) {

--- a/src/main/java/com/codessquad/qna/dto/QuestionDto.java
+++ b/src/main/java/com/codessquad/qna/dto/QuestionDto.java
@@ -10,16 +10,15 @@ public class QuestionDto {
     private User writer;
     private String title;
     private String contents;
-    private String time;
+    private String createdAt;
 
     protected QuestionDto() {
-
     }
 
     public QuestionDto(String title, String contents) {
         this.title = title;
         this.contents = contents;
-        this.time = DateTimeUtils.stringOf(LocalDateTime.now());
+        this.createdAt = DateTimeUtils.stringOf(LocalDateTime.now());
     }
 
     public User getWriter() {
@@ -47,11 +46,11 @@ public class QuestionDto {
     }
 
     public String getTime() {
-        return time;
+        return createdAt;
     }
 
-    public void setTime(String time) {
-        this.time = time;
+    public void setTime(String createdAt) {
+        this.createdAt = createdAt;
     }
 
     public Question toEntity(User user) {

--- a/src/main/java/com/codessquad/qna/dto/QuestionDto.java
+++ b/src/main/java/com/codessquad/qna/dto/QuestionDto.java
@@ -45,11 +45,11 @@ public class QuestionDto {
         this.contents = contents;
     }
 
-    public String getTime() {
+    public String getCreatedAt() {
         return createdAt;
     }
 
-    public void setTime(String createdAt) {
+    public void setCreatedAt(String createdAt) {
         this.createdAt = createdAt;
     }
 

--- a/src/main/java/com/codessquad/qna/exception/ControllerExceptionHandler.java
+++ b/src/main/java/com/codessquad/qna/exception/ControllerExceptionHandler.java
@@ -8,6 +8,6 @@ public class ControllerExceptionHandler {
 
     @ExceptionHandler(NotLoginException.class)
     public String handleNotLoginException() {
-        return "redirect:/users/loginForm";
+        return "user/login_failed";
     }
 }

--- a/src/main/java/com/codessquad/qna/service/AnswerService.java
+++ b/src/main/java/com/codessquad/qna/service/AnswerService.java
@@ -19,27 +19,26 @@ public class AnswerService {
     }
 
     @Transactional
-    public long create(User user, long questionId, String contents) {
+    public void create(User user, long questionId, String contents) {
         Question question = questionRepository.findById(questionId).orElseThrow(IllegalArgumentException::new);
         Answer answer = new Answer(user, question, contents);
         answerRepository.save(answer);
-        return question.getId();
     }
 
     public List<Answer> findAnswersByQuestionId(long questionId) {
         return answerRepository.findAnswersByQuestionId(questionId);
     }
 
-    @Transactional
-    public long delete(long answerId, User user) {
-        Answer answer = answerRepository.findById(answerId).orElseThrow(IllegalArgumentException::new);
-        if (verifyAnswer(answer, user)) {
-            answerRepository.delete(answer);
-        }
-        return answer.getQuestion().getId();
+    public Answer findAnswerByAnswerId(long answerId){
+        return answerRepository.findById(answerId).orElseThrow(IllegalArgumentException::new);
     }
 
-    public boolean verifyAnswer(Answer answer, User sessionedUser) {
-        return sessionedUser.isMatchingUserId(answer.getWriter());
+    @Transactional
+    public boolean delete(Answer answer, User user) {
+        if (answer.isMatchingWriter(user)) {
+            answerRepository.delete(answer);
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/com/codessquad/qna/service/AnswerService.java
+++ b/src/main/java/com/codessquad/qna/service/AnswerService.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
-public class AnswerService {
+public class AnswerService{
 
     private final AnswerRepository answerRepository;
     private final QuestionRepository questionRepository;
@@ -29,7 +29,7 @@ public class AnswerService {
         return answerRepository.findAnswersByQuestionId(questionId);
     }
 
-    public Answer findAnswerByAnswerId(long answerId){
+    public Answer findAnswerByAnswerId(long answerId) {
         return answerRepository.findById(answerId).orElseThrow(IllegalArgumentException::new);
     }
 

--- a/src/main/java/com/codessquad/qna/service/QuestionService.java
+++ b/src/main/java/com/codessquad/qna/service/QuestionService.java
@@ -12,6 +12,7 @@ import java.util.List;
 @Service
 @Transactional(readOnly = true)
 public class QuestionService {
+
     private final QuestionRepository questionRepository;
 
     public QuestionService(QuestionRepository questionRepository) {

--- a/src/main/java/com/codessquad/qna/service/QuestionService.java
+++ b/src/main/java/com/codessquad/qna/service/QuestionService.java
@@ -26,9 +26,11 @@ public class QuestionService {
 
     @Transactional
     public void update(Question updateQuestion, long questionId, User sessionedUser) {
-        Question question = verifyQuestion(questionId, sessionedUser);
-        question.update(updateQuestion);
-        questionRepository.save(question);
+        Question question = findQuestionById(questionId);
+        if (question.isMatchingWriter(sessionedUser)) {
+            question.update(updateQuestion);
+            questionRepository.save(question);
+        }
     }
 
     public List<Question> findQuestions() {
@@ -40,16 +42,11 @@ public class QuestionService {
     }
 
     @Transactional
-    public void delete(long questionId, User user) {
-        Question question = verifyQuestion(questionId, user);
-        questionRepository.delete(question);
-    }
-
-    public Question verifyQuestion(long questionId, User sessionedUser) {
-        Question question = findQuestionById(questionId);
-        if (!sessionedUser.isMatchingUserId(question.getWriter())) {
-            throw new IllegalStateException("자신의 질문만 수정할 수 있습니다.");
+    public boolean delete(Question question, User user) {
+        if (question.isMatchingWriter(user)) {
+            questionRepository.delete(question);
+            return true;
         }
-        return question;
+        return false;
     }
 }

--- a/src/main/java/com/codessquad/qna/service/UserService.java
+++ b/src/main/java/com/codessquad/qna/service/UserService.java
@@ -35,7 +35,7 @@ public class UserService {
         return userRepository.findUserByUserId(userId).orElseThrow(() -> new NotLoginException("로그인하실 수 없습니다."));
     }
 
-    public boolean isNewUser(User user){
+    public boolean isNewUser(User user) {
         return !userRepository.findUserByUserId(user.getUserId()).isPresent();
     }
 }

--- a/src/main/java/com/codessquad/qna/service/UserService.java
+++ b/src/main/java/com/codessquad/qna/service/UserService.java
@@ -2,6 +2,7 @@ package com.codessquad.qna.service;
 
 import com.codessquad.qna.domain.User;
 import com.codessquad.qna.domain.UserRepository;
+import com.codessquad.qna.exception.NotLoginException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,6 +32,10 @@ public class UserService {
     }
 
     public User findUserByUserId(String userId) {
-        return userRepository.findUserByUserId(userId).orElseThrow(IllegalAccessError::new);
+        return userRepository.findUserByUserId(userId).orElseThrow(() -> new NotLoginException("로그인하실 수 없습니다."));
+    }
+
+    public boolean isNewUser(User user){
+        return !userRepository.findUserByUserId(user.getUserId()).isPresent();
     }
 }

--- a/src/main/resources/templates/component/navbar.html
+++ b/src/main/resources/templates/component/navbar.html
@@ -53,7 +53,7 @@
         </div>
         <div class="collapse navbar-collapse" id="navbar-collapse2">
             <ul class="nav navbar-nav navbar-right">
-                <li class="active"><a href="/">Posts</a></li>
+                <li class="active"><a href="/questions">Posts</a></li>
                 {{^sessionedUser}}
                 <li><a href="/users/loginForm" role="button">로그인</a></li>
                 <li><a href="/users/form" role="button">회원가입</a></li>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -12,7 +12,7 @@
                             </strong>
                             <div class="auth-info">
                                 <i class="icon-add-comment"></i>
-                                <span class="time">{{formatDateTime time}}</span>
+                                <span class="time">{{formatDateTime createdAt}}</span>
                                 <a href="/user/profile" class="author">{{writer.userId}}</a>
                             </div>
                             <div class="reply" title="댓글">

--- a/src/main/resources/templates/qna/form.html
+++ b/src/main/resources/templates/qna/form.html
@@ -12,6 +12,7 @@
                     <textarea name="contents" id="contents" rows="5" class="form-control"></textarea>
                 </div>
                 <button type="submit" class="btn btn-success clearfix pull-right">질문하기</button>
+                <div class="clearfix"/>
             </form>
         </div>
     </div>

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -4,6 +4,9 @@
         <div class="panel panel-default">
             <header class="qna-header">
                 <h2 class="qna-title">{{question.title}}</h2>
+                {{#error}}
+                <div class="alert alert-danger" role="alert">{{error}}</div>
+                {{/error}}
             </header>
             <div class="content-main">
                 <article class="article">
@@ -14,8 +17,7 @@
                         </div>
                         <div class="article-header-text">
                             <a href="/users/{{question.writer.id}}" class="article-author-name">{{question.writer.userId}}</a>
-                            <a href="/questions/413" class="article-header-time" title="퍼머링크">
-                                {{question.time}}
+                            <a href="/questions/413" class="article-header-time" title="퍼머링크">{{formatDateTime question.time}}
                                 <i class="icon-link"></i>
                             </a>
                         </div>
@@ -33,9 +35,6 @@
                                     <input type="hidden" name="_method" value="DELETE">
                                     <button class="link-delete-article" type="submit">삭제</button>
                                 </form>
-                            </li>
-                            <li>
-                                <a class="link-modify-article" href="/index.html">목록</a>
                             </li>
                         </ul>
                     </div>
@@ -63,10 +62,6 @@
                                 </div>
                                 <div class="article-util">
                                     <ul class="article-util-list">
-                                        <li>
-                                            <a class="link-modify-article"
-                                               href="/questions/413/answers/1405/form">수정</a>
-                                        </li>
                                         <li>
                                             <form class="delete-answer-form"
                                                   action="/questions/{{question.id}}/answers/{{id}}"
@@ -111,9 +106,6 @@
         </div>
         <div class="article-util">
             <ul class="article-util-list">
-                <li>
-                    <a class="link-modify-article" href="/api/qna/updateAnswer/{3}">수정</a>
-                </li>
                 <li>
                     <form class="delete-answer-form" action="/api/questions/{3}/answers/{4}" method="POST">
                         <input type="hidden" name="_method" value="DELETE">

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -17,7 +17,7 @@
                         </div>
                         <div class="article-header-text">
                             <a href="/users/{{question.writer.id}}" class="article-author-name">{{question.writer.userId}}</a>
-                            <a href="/questions/413" class="article-header-time" title="퍼머링크">{{formatDateTime question.time}}
+                            <a href="/questions/413" class="article-header-time" title="퍼머링크">{{formatDateTime question.createdAt}}
                                 <i class="icon-link"></i>
                             </a>
                         </div>
@@ -53,7 +53,7 @@
                                     </div>
                                     <div class="article-header-text">
                                         <a href="/users/1/자바지기" class="article-author-name">{{writer.userId}}</a>
-                                        {{formatDateTime time}}
+                                        {{formatDateTime createdAt}}
                                         </a>
                                     </div>
                                 </div>

--- a/src/main/resources/templates/qna/updateForm.html
+++ b/src/main/resources/templates/qna/updateForm.html
@@ -13,6 +13,7 @@
                     <textarea name="contents" id="contents" rows="5" class="form-control" >{{question.contents}}</textarea>
                 </div>
                 <button type="submit" class="btn btn-success clearfix pull-right">수정하기</button>
+                <div class="clearfix"/>
             </form>
         </div>
     </div>

--- a/src/main/resources/templates/user/create_failed.html
+++ b/src/main/resources/templates/user/create_failed.html
@@ -1,0 +1,31 @@
+{{#partial "content"}}
+<div class="container" id="main">
+    <div class="col-md-6 col-md-offset-3">
+        <div class="panel panel-default content-main">
+            <div class="alert alert-danger" role="alert">중복된 아이디이거나 비어있는 부분이 존재합니다. 다시 입력해주세요.</div>
+            <form name="question" method="post" action="/users">
+                <div class="form-group">
+                    <label for="userId">사용자 아이디</label>
+                    <input class="form-control" id="userId" name="userId" placeholder="User ID">
+                </div>
+                <div class="form-group">
+                    <label for="password">비밀번호</label>
+                    <input type="password" class="form-control" id="password" name="password" placeholder="Password">
+                </div>
+                <div class="form-group">
+                    <label for="name">이름</label>
+                    <input class="form-control" id="name" name="name" placeholder="Name">
+                </div>
+                <div class="form-group">
+                    <label for="email">이메일</label>
+                    <input type="email" class="form-control" id="email" name="email" placeholder="Email">
+                </div>
+                <button type="submit" class="btn btn-success clearfix pull-right">회원가입</button>
+                <div class="clearfix"/>
+            </form>
+        </div>
+    </div>
+</div>
+{{/partial}}
+
+{{> component/base}}

--- a/src/main/resources/templates/user/list.html
+++ b/src/main/resources/templates/user/list.html
@@ -2,6 +2,9 @@
 <div class="container" id="main">
     <div class="col-md-10 col-md-offset-1">
         <div class="panel panel-default">
+            {{#error}}
+            <div class="alert alert-danger" role="alert">{{error}}</div>
+            {{/error}}
             <table class="table table-hover">
                 <thead>
                 <tr>

--- a/src/main/resources/templates/user/login_failed.html
+++ b/src/main/resources/templates/user/login_failed.html
@@ -2,8 +2,8 @@
 <div class="container" id="main">
     <div class="col-md-6 col-md-offset-3">
         <div class="panel panel-default content-main">
-            <div class="alert alert-danger" role="alert">아이디 또는 비밀번호가 틀립니다. 다시 로그인 해주세요.</div>
-            <form name="question" method="post" action="/user/login">
+            <div class="alert alert-danger" role="alert">다시 로그인 해주세요.</div>
+            <form name="question" method="post" action="/users/login">
                 <div class="form-group">
                     <label for="userId">사용자 아이디</label>
                     <input class="form-control" id="userId" name="userId" placeholder="User ID">

--- a/src/main/resources/templates/user/updateForm.html
+++ b/src/main/resources/templates/user/updateForm.html
@@ -25,6 +25,7 @@
                     <input type="email" class="form-control" id="email" name="email" placeholder="Email">
                 </div>
                 <button type="submit" class="btn btn-success clearfix pull-right">회원정보수정</button>
+                <div class="clearfix"/>
             </form>
         </div>
     </div>

--- a/src/main/resources/templates/user/updateForm.html
+++ b/src/main/resources/templates/user/updateForm.html
@@ -2,11 +2,11 @@
 <div class="container" id="main">
     <div class="col-md-6 col-md-offset-3">
         <div class="panel panel-default content-main">
-            <form name="question" method="post" action="/users/{{user.id}}/update">
+            <form name="question" method="post" action="/users/{{user.id}}">
                 <input type="hidden" name="_method" value="put" />
                 <div class="form-group">
                     <label for="userId">사용자 아이디</label>
-                    <input class="form-control" id="userId" name="userId" placeholder="User ID" value="{{user.userId}}">
+                    <input class="form-control" id="userId" name="userId" placeholder="User ID" value="{{user.userId}}" readonly>
                 </div>
                 <div class="form-group">
                     <label for="oldPassword">기존 비밀번호</label>
@@ -22,7 +22,7 @@
                 </div>
                 <div class="form-group">
                     <label for="email">이메일</label>
-                    <input type="email" class="form-control" id="email" name="email" placeholder="Email">
+                    <input type="email" class="form-control" id="email" name="email" placeholder="Email" value="{{user.email}}">
                 </div>
                 <button type="submit" class="btn btn-success clearfix pull-right">회원정보수정</button>
                 <div class="clearfix"/>

--- a/src/main/resources/templates/user/update_failed.html
+++ b/src/main/resources/templates/user/update_failed.html
@@ -1,0 +1,36 @@
+{{#partial "content"}}
+<div class="container" id="main">
+    <div class="col-md-6 col-md-offset-3">
+        <div class="panel panel-default content-main">
+            <form name="question" method="post" action="/users/{{user.id}}">
+                <div class="alert alert-danger" role="alert">기존 비밀번호가 일치하지 않습니다. 다시 입력해주세요.</div>
+                <input type="hidden" name="_method" value="put" />
+                <div class="form-group">
+                    <label for="userId">사용자 아이디</label>
+                    <input class="form-control" id="userId" name="userId" placeholder="User ID" value="{{user.userId}}" readonly>
+                </div>
+                <div class="form-group">
+                    <label for="oldPassword">기존 비밀번호</label>
+                    <input type="password" class="form-control" id="oldPassword" name="oldPassword" placeholder="oldPassword">
+                </div>
+                <div class="form-group">
+                    <label for="password">새 비밀번호</label>
+                    <input type="password" class="form-control" id="password" name="password" placeholder="Password">
+                </div>
+                <div class="form-group">
+                    <label for="name">이름</label>
+                    <input class="form-control" id="name" name="name" placeholder="Name" value="{{user.name}}">
+                </div>
+                <div class="form-group">
+                    <label for="email">이메일</label>
+                    <input type="email" class="form-control" id="email" name="email" placeholder="Email" value="{{user.email}}">
+                </div>
+                <button type="submit" class="btn btn-success clearfix pull-right">회원정보수정</button>
+                <div class="clearfix"/>
+            </form>
+        </div>
+    </div>
+</div>
+{{/partial}}
+
+{{> component/base}}


### PR DESCRIPTION
#### 1. 중복 userId로 회원 가입이 가능한 문제
 - 중복 userId 체크
   - UserService에서 isNewUser() 구현

#### 2. 사용자 입력에 대한 유효성 검사
  - User 객체 생성 시 필요한 값들이 모두 있는지 체크
    - form에서 받아온 User 정보 중 빠진 정보가 있는지 확인 
    - User.isEmpty()구현

#### 3. 500 에러 처리
 - (1) 에러 메시지 출력
    - html 페이지에 에러 메시지 출력을 위한 코드 추가
      - {{#error}},{{/error}} 추가
    - 컨트롤러 메소드에서 요청 작업 처리 중 에러 발생 시, Model에 에러 메시지 추가
    - 클라이언트에서는 넘겨받은 에러 메시지 출력

 - (2) 회원 정보 수정 관련 처리
   - 비밀 번호 일치하지 않을 경우 에러 페이지 리턴
      - user/update_failed.html로 리턴
    - 그 밖의 경우, 회원 정보 수정 실패 시, Model에 에러 메시지 추가
       - UserController의 viewUpdateUserForm()에서 Model 사용(파라미터에 Model 추가)
       - 에러 발생 시 Model에 에러 메시지 추가

 - (3) 댓글 삭제 관련 처리
    - 삭제 대상 댓글 <> 로그인 유저 정보 일 경우, Model에 에러 메시지 추가
      - AnswerController의 delete()에서 Model 사용(파라미터에 Model 추가)
    - 삭제 여부 확인을 위해 AnswerSerivce에서 boolean 리턴
      - 리턴된 boolean 값 == false == 댓글 삭제 실패

 - (4) 질문 수정 및 삭제 관련 처리
    - 질문 수정 및 삭제 실패 시, Model에 에러 메시지 추가
      - QuestionController의 delete()과 update()에서 Model 사용(파라미터에 Model 추가)
    - 삭제 여부 확인을 위해 QuestionSerivce에서 boolean 리턴
      - 리턴된 boolean 값 == false == 질문 수정 및 삭제 실패

#### 4. 그밖의 사용성 개선
 - 에러 발생 시 에러 페이지로 이동
   - '중복 userId 문제' 혹은 '사용자 입력 유효성 문제' 발생 시 에러 페이지로 이동
   - 에러 페이지 create_failed.html 생성
 - 질문 글 수정 완료 후 해당하는 글로 이동
   - `return "redirect:/";` → `return "redirect:/" + questionId`

#### 5. UI 문제
 - CSS 깨지는 문제
   - `<div class="clearfix"/>` 추가

 - 수정 화면에서 이메일 input 태그에 value 값 추가
   - value="{{user.email}} 추가

#### 6. 리팩토링
  - (1) HomeController 클래스 구현
    - 메인 페이지로 이동하는 메소드 구현
      - @GetMapping("/") visit()
      - "/" url이 요청이 올 경우 "/questions"로 리다이렉트
  - (2) QuestionController 공통 url 분리
    - 전체 메소드 매핑에 중복되는 "/questions"를 @RequestMapping으로 묶음
  - (3) AnswerSerivce의 verifyAnswer 제거
    - 대신, Answer 클래스 내부에서 writer와 인자로 받은 user 정보를 비교
      - Answer 클래스에 isMatchingWriter(User user) 구현